### PR TITLE
Prevent adding coordinate properties of df as properties to GeoJSON

### DIFF
--- a/mapboxgl/utils.py
+++ b/mapboxgl/utils.py
@@ -9,9 +9,7 @@ def df_to_geojson(df, properties=None, lat='lat', lon='lon', precision=None):
         df[lon] = df[lon].round(precision)
 
     if not properties:
-        properties = list(df.columns)
-        properties.remove(lat)
-        properties.remove(lon)
+        properties = [c for c in df.columns if c not in [lat, lon]]
 
     for _, row in df.iterrows():
         feature = {

--- a/mapboxgl/utils.py
+++ b/mapboxgl/utils.py
@@ -10,6 +10,8 @@ def df_to_geojson(df, properties=None, lat='lat', lon='lon', precision=None):
 
     if not properties:
         properties = list(df.columns)
+        properties.remove(lat)
+        properties.remove(lon)
 
     for _, row in df.iterrows():
         feature = {
@@ -28,7 +30,7 @@ def df_to_geojson(df, properties=None, lat='lat', lon='lon', precision=None):
     return geojson
 
 def scale_between(minval, maxval, numStops):
-    """ Scale a min and max value to equal interval domain with 
+    """ Scale a min and max value to equal interval domain with
         numStops discrete values
     """
 

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -16,7 +16,9 @@ class MockDataframe(object):
 
     @property
     def columns(self):
-        return list(self.features[0]['properties'].keys())
+        properties = list(self.features[0]['properties'].keys())
+        properties.extend([self.lat, self.lon])
+        return properties
 
     def iterrows(self):
         for i, row in enumerate(self.features):
@@ -31,6 +33,17 @@ class MockDataframe(object):
 def df():
     with open('tests/points.geojson') as fh:
         data = json.loads(fh.read())
+
+    return MockDataframe(data['features'])
+
+@pytest.fixture()
+def df_no_properties():
+    with open('tests/points.geojson') as fh:
+        data = json.loads(fh.read())
+
+    for feature in data['features']:
+        feature['properties'] = {}
+
     return MockDataframe(data['features'])
 
 
@@ -43,6 +56,12 @@ def test_df_properties(df):
     features = df_to_geojson(df, properties=['Avg Medicare Payments'])[
         'features']
     assert tuple(features[0]['properties'].keys()) == ('Avg Medicare Payments',)
+
+
+def test_df_no_properties(df_no_properties):
+    features = df_to_geojson(df_no_properties)[
+        'features']
+    assert tuple(features[0]['properties'].keys()) == ()
 
 
 def test_scale_between():
@@ -66,4 +85,3 @@ def test_create_radius_stops(df):
     domain = [7678.214347826088, 5793.63142857143, 1200]
     radius_stops = create_radius_stops(domain, 1, 10)
     assert radius_stops == [[7678.214347826088, 1.0], [5793.63142857143, 4.0], [1200, 7.0]]
-


### PR DESCRIPTION
If no properties are defined in the `df_to_geojson` method, it currently puts the `lat` and `lon` properties into the GeoJSON properties, which is not useful. 

This PR tries to resolve this bug (https://github.com/mapbox/mapboxgl-jupyter/issues/12).

It is my first PR to this repo and I would appreciate any feedback/edits.