### PR TITLE
Expose better default and fallback Mapbox GL style value options

### DIFF
--- a/mapboxgl/templates/circle.html
+++ b/mapboxgl/templates/circle.html
@@ -63,8 +63,8 @@ map.on('style.load', function() {
         "paint": {
             "circle-color": generatePropertyExpression("{{ colorType }}", "{{ colorProperty }}", {{ colorStops }}, "{{ defaultColor }}" ),
             "circle-radius" : generatePropertyExpression('interpolate', 'zoom', [[0,1], [18,10]]),
-            "circle-stroke-color": "white",
-            "circle-stroke-width": generatePropertyExpression('interpolate', 'zoom', [[0,0.01], [18,1]]),
+            "circle-stroke-color": "{{ strokeColor }}",
+            "circle-stroke-width": {{ strokeWidth }},
             "circle-opacity" : {{ opacity }}
         }
     }, "label");

--- a/mapboxgl/templates/heatmap.html
+++ b/mapboxgl/templates/heatmap.html
@@ -42,7 +42,14 @@ map.on('style.load', function() {
         "maxzoom": {{ maxzoom }},
         "minzoom": {{ minzoom }},
         "paint": {
-            "heatmap-weight": generateInterpolateExpression( "{{ weightProperty }}", {{ weightStops }} ),
+            {% if weightProperty %}
+                {% if weightStops %}
+                    "heatmap-weight": generateInterpolateExpression( "{{ weightProperty }}", {{ weightStops }} ),
+                {% endif %}
+            {% endif %}
+            {% if intensityStops %}
+                "heatmap-intensity": generateInterpolateExpression('zoom', {{ intensityStops }} ),
+            {% endif %}
             "heatmap-radius" : generateInterpolateExpression('zoom', {{ radiusStops }} ),
             "heatmap-color" : generateInterpolateExpression('heatmap-density', {{ colorStops }} ),
             "heatmap-opacity" : {{ opacity }}

--- a/mapboxgl/templates/main.html
+++ b/mapboxgl/templates/main.html
@@ -85,13 +85,13 @@ function calcCircleColorLegend(myColorStops, title) {
 function generateInterpolateExpression(propertyValue, stops) {
     var expression;
     if (propertyValue == 'zoom') {
-        expression = ['interpolate', ['linear'], ['zoom']]
+        expression = ['interpolate', ['exponential', 1.2], ['zoom']]
     }
     else if (propertyValue == 'heatmap-density') {
-        expression = ['interpolate', ['linear'], ['heatmap-density']]
+        expression = ['interpolate', ['exponential', 1.2], ['heatmap-density']]
     }
     else {
-        expression = ['interpolate', ['linear'], ['get', propertyValue]]
+        expression = ['interpolate', ['exponential', 1.2], ['get', propertyValue]]
     }
 
     for (var i=0; i<stops.length; i++) {

--- a/mapboxgl/viz.py
+++ b/mapboxgl/viz.py
@@ -116,6 +116,8 @@ class CircleViz(MapViz):
                  color_stops=None,
                  color_default='grey',
                  color_function_type='interpolate',
+                 stroke_color='white',
+                 stoke_width=1,
                  *args,
                  **kwargs):
         """Construct a Mapviz object
@@ -135,6 +137,8 @@ class CircleViz(MapViz):
         self.color_stops = color_stops
         self.color_function_type = color_function_type
         self.color_default = color_default
+        self.stroke_color = color_default
+        self.stroke_width = color_default
 
     def add_unique_template_variables(self, options):
         """Update map template variables specific to circle visual"""
@@ -143,7 +147,9 @@ class CircleViz(MapViz):
             colorProperty=self.color_property,
             colorType=self.color_function_type,
             colorStops=self.color_stops,
-            defaultColor=self.color_default
+            defaultColor=self.color_default,
+            strokeColor=self.stroke_color,
+            strokeWidth=self.stroke_width
         ))
 
 
@@ -212,6 +218,7 @@ class HeatmapViz(MapViz):
                  weight_stops=None,
                  color_stops=None,
                  radius_stops=None,
+                 intensity_stops=None,
                  *args,
                  **kwargs):
         """Construct a Mapviz object
@@ -220,6 +227,7 @@ class HeatmapViz(MapViz):
         :param weight_stops: stops to determine heatmap weight.  EX. [[10, 0], [100, 1]]
         :param color_stops: stops to determine heatmap color.  EX. [[0, "red"], [0.5, "blue"], [1, "green"]]
         :param radius_stops: stops to determine heatmap radius based on zoom.  EX: [[0, 1], [12, 30]]
+        :param intensity_stops: stops to determine the heatmap intensity based on zoom. EX: [[0, 0.1], [20, 5]]
 
         """
         super(HeatmapViz, self).__init__(data, *args, **kwargs)
@@ -229,6 +237,11 @@ class HeatmapViz(MapViz):
         self.weight_stops = weight_stops
         self.color_stops = color_stops
         self.radius_stops = radius_stops
+        self.intensity_stops = intensity_stops
+
+        if self.color_stops:
+            # Make the first color stop in a heatmap have opacity 0 for good visual effect
+            self.color_stops = [[0.00001, 'rgba(0,0,0,0)']] + self.color_stops
 
     def add_unique_template_variables(self, options):
         """Update map template variables specific to heatmap visual"""
@@ -236,7 +249,8 @@ class HeatmapViz(MapViz):
             colorStops=self.color_stops,
             radiusStops=self.radius_stops,
             weightProperty=self.weight_property,
-            weightStops=self.weight_stops
+            weightStops=self.weight_stops,
+            intensityStops=self.intensity_stops
         ))
 
 


### PR DESCRIPTION
In this PR, I want to make it consistent across all visualization types that a user:

1. Is not required to pass any map style options.  If a user does not pass a map style option, the map will display with default options (for things like radius, weight, color, etc).
2. Can specify either a static value `radius: 3` or an expression `radius: ['interpolate', ['linear'], ['zoom'], 0, 1, 22, 10]` for each style property for a viz type.  
    * In order to achieve this, create a utility python function `create_expression(type, property, stops)` that generated the expression in the viz class.  
    * Then each html jinja template can simply display the style value if it exists.  If not, do not specify it and the default will be used.


Completed so far:
* Removed requirement for `heatmap-weight` to be passed as an argument to the HeatmapViz
* Added `circle-stroke-width` and `circle-stroke-color` to CircleViz