### PR TITLE
Fix MapViz to allow the use of a non-mapbox style without raising a TokenError and add error propagation from JS

### DIFF
--- a/docs-markdown/viz.md
+++ b/docs-markdown/viz.md
@@ -21,14 +21,14 @@
 The `MapViz` class is the parent class of the various `mapboxgl-jupyter` visualizations. You can use this class to set default values for all visualizations rather than calling them directly from the other visualization objects.
 
 ### Params
-**MapViz**(_data, access_token=None, center=(0, 0), below_layer='', opacity=1, div_id='map', height='500px', style_url='mapbox://styles/mapbox/light-v9?optimize=true', width='100%', zoom=0, min_zoom=0, max_zoom=24_)
+**MapViz**(_data, access_token=None, center=(0, 0), below_layer='', opacity=1, div_id='map', height='500px', style='mapbox://styles/mapbox/light-v9?optimize=true', width='100%', zoom=0, min_zoom=0, max_zoom=24_)
 
 Parameter | Description
 --|--
 data | GeoJSON Feature Collection
 access_token | Mapbox GL JS access token.
 center | map center point
-style_url | url to mapbox style
+style | url to mapbox style or stylesheet as a Python dictionary in JSON format
 div_id | The HTML div id of the map container in the viz
 width | The CSS width of the HTML div id in % or pixels.
 height | The CSS height of the HTML map div in % or pixels.

--- a/examples/point-viz-types-example.ipynb
+++ b/examples/point-viz-types-example.ipynb
@@ -1321,7 +1321,7 @@
     }
    ],
    "source": [
-    "viz.style_url='mapbox://styles/mapbox/dark-v9?optimize=true'\n",
+    "viz.style='mapbox://styles/mapbox/dark-v9?optimize=true'\n",
     "viz.show()"
    ]
   },

--- a/mapboxgl/templates/base.html
+++ b/mapboxgl/templates/base.html
@@ -8,7 +8,7 @@ mapboxgl.accessToken = '{{ accessToken }}';
 
 var map = new mapboxgl.Map({
     container: 'map',
-    style: '{{ styleUrl }}', 
+    style: {{ style }},
     center: {{ center }},
     zoom: {{ zoom }},
     transformRequest: (url, resourceType)=> {

--- a/mapboxgl/templates/circle.html
+++ b/mapboxgl/templates/circle.html
@@ -5,7 +5,7 @@ mapboxgl.accessToken = '{{ accessToken }}';
 
 var map = new mapboxgl.Map({
     container: 'map',
-    style: '{{ styleUrl }}', 
+    style: {{ style }},
     center: {{ center }},
     zoom: {{ zoom }},
     transformRequest: (url, resourceType)=> {

--- a/mapboxgl/templates/clustered_circle.html
+++ b/mapboxgl/templates/clustered_circle.html
@@ -5,7 +5,7 @@ mapboxgl.accessToken = '{{ accessToken }}';
 
 var map = new mapboxgl.Map({
     container: 'map',
-    style: '{{ styleUrl }}', 
+    style: {{ style }},
     center: {{ center }},
     zoom: {{ zoom }},
     transformRequest: (url, resourceType)=> {

--- a/mapboxgl/templates/graduated_circle.html
+++ b/mapboxgl/templates/graduated_circle.html
@@ -5,7 +5,7 @@ mapboxgl.accessToken = '{{ accessToken }}';
 
 var map = new mapboxgl.Map({
     container: 'map',
-    style: '{{ styleUrl }}', 
+    style: {{ style }},
     center: {{ center }},
     zoom: {{ zoom }},
     transformRequest: (url, resourceType)=> {

--- a/mapboxgl/templates/heatmap.html
+++ b/mapboxgl/templates/heatmap.html
@@ -5,7 +5,7 @@ mapboxgl.accessToken = '{{ accessToken }}';
 
 var map = new mapboxgl.Map({
     container: 'map',
-    style: '{{ styleUrl }}', 
+    style: {{ style }},
     center: {{ center }},
     zoom: {{ zoom }},
     transformRequest: (url, resourceType)=> {

--- a/mapboxgl/viz.py
+++ b/mapboxgl/viz.py
@@ -39,6 +39,10 @@ class MapViz(object):
         """
         if access_token is None:
             access_token = os.environ.get('MAPBOX_ACCESS_TOKEN', '')
+        if access_token.startswith('sk'):
+            raise TokenError('Mapbox access token must be public (pk), not secret (sk). ' \
+                             'Please sign up at https://www.mapbox.com/signup/ to get a public token. ' \
+                             'If you already have an account, you can retreive your token at https://www.mapbox.com/account/.')
         self.access_token = access_token
         self.template = 'base'
         self.data = data

--- a/mapboxgl/viz.py
+++ b/mapboxgl/viz.py
@@ -39,7 +39,7 @@ class MapViz(object):
         """
         if access_token is None:
             access_token = os.environ.get('MAPBOX_ACCESS_TOKEN', '')
-        if not access_token.startswith('pk'):
+        if style_url.startswith('mapbox:') and not access_token.startswith('pk'):
             raise TokenError('Mapbox access token must be public (pk). ' \
                              'Please sign up at https://www.mapbox.com/signup/ to get a public token. ' \
                              'If you already have an account, you can retreive your token at https://www.mapbox.com/account/.')

--- a/mapboxgl/viz.py
+++ b/mapboxgl/viz.py
@@ -19,7 +19,7 @@ class MapViz(object):
                  opacity=1,
                  div_id='map',
                  height='500px',
-                 style_url='mapbox://styles/mapbox/light-v9?optimize=true',
+                 style='mapbox://styles/mapbox/light-v9?optimize=true',
                  width='100%',
                  zoom=0,
                  min_zoom=0,
@@ -29,7 +29,7 @@ class MapViz(object):
         :param data: GeoJSON Feature Collection
         :param access_token: Mapbox GL JS access token.
         :param center: map center point
-        :param style_url: url to mapbox style
+        :param style: url to mapbox style or stylesheet as a Python dictionary in JSON format
         :param div_id: The HTML div id of the map container in the viz
         :param width: The CSS width of the HTML div id in % or pixels.
         :param height: The CSS height of the HTML map div in % or pixels.
@@ -39,18 +39,13 @@ class MapViz(object):
         """
         if access_token is None:
             access_token = os.environ.get('MAPBOX_ACCESS_TOKEN', '')
-        if style_url.startswith('mapbox:') and not access_token.startswith('pk'):
-            raise TokenError('Mapbox access token must be public (pk). ' \
-                             'Please sign up at https://www.mapbox.com/signup/ to get a public token. ' \
-                             'If you already have an account, you can retreive your token at https://www.mapbox.com/account/.')
         self.access_token = access_token
-
         self.template = 'base'
         self.data = data
         self.div_id = div_id
         self.width = width
         self.height = height
-        self.style_url = style_url
+        self.style = style
         self.center = center
         self.zoom = zoom
         self.below_layer = below_layer
@@ -83,11 +78,15 @@ class MapViz(object):
 
     def create_html(self):
         """Create a circle visual from a geojson data source"""
+        if isinstance(self.style, str):
+            style = "'{}'".format(self.style)
+        else:
+            style = self.style
         options = dict(
             gl_js_version=GL_JS_VERSION,
             accessToken=self.access_token,
             div_id=self.div_id,
-            styleUrl=self.style_url,
+            style=style,
             center=list(self.center),
             zoom=self.zoom,
             geojson_data=json.dumps(self.data, ensure_ascii=False),

--- a/tests/test_html.py
+++ b/tests/test_html.py
@@ -4,7 +4,6 @@ from mock import patch
 import pytest
 
 from mapboxgl.viz import *
-from mapboxgl.errors import TokenError
 
 
 @pytest.fixture()
@@ -14,22 +13,6 @@ def data():
 
 
 TOKEN = 'pk.abc123'
-
-
-def test_secret_key_CircleViz(data):
-    """Secret key raises a token error
-    """
-    secret = 'sk.abc123'
-    with pytest.raises(TokenError):
-        CircleViz(data, access_token=secret)
-
-
-def test_secret_key_GraduatedCircleViz(data):
-    """Secret key raises a token error
-    """
-    secret = 'sk.abc123'
-    with pytest.raises(TokenError):
-        GraduatedCircleViz(data, access_token=secret)
 
 
 def test_token_env_CircleViz(monkeypatch, data):

--- a/tests/test_html.py
+++ b/tests/test_html.py
@@ -4,6 +4,7 @@ from mock import patch
 import pytest
 
 from mapboxgl.viz import *
+from mapboxgl.errors import TokenError
 
 
 @pytest.fixture()
@@ -13,6 +14,22 @@ def data():
 
 
 TOKEN = 'pk.abc123'
+
+
+def test_secret_key_CircleViz(data):
+    """Secret key raises a token error
+    """
+    secret = 'sk.abc123'
+    with pytest.raises(TokenError):
+        CircleViz(data, access_token=secret)
+
+
+def test_secret_key_GraduatedCircleViz(data):
+    """Secret key raises a token error
+    """
+    secret = 'sk.abc123'
+    with pytest.raises(TokenError):
+        GraduatedCircleViz(data, access_token=secret)
 
 
 def test_token_env_CircleViz(monkeypatch, data):


### PR DESCRIPTION
Fixes #58.