### PR TITLE
Bugfix for choropleth fill with large numeric color stops

### DIFF
--- a/mapboxgl/templates/main.html
+++ b/mapboxgl/templates/main.html
@@ -90,10 +90,10 @@ function generateInterpolateExpression(propertyValue, stops) {
         expression = ['interpolate', ['exponential', 1.2], ['zoom']]
     }
     else if (propertyValue == 'heatmap-density') {
-        expression = ['interpolate', ['exponential', 1.2], ['heatmap-density']]
+        expression = ['interpolate', ['linear'], ['heatmap-density']]
     }
     else {
-        expression = ['interpolate', ['exponential', 1.2], ['get', propertyValue]]
+        expression = ['interpolate', ['linear'], ['get', propertyValue]]
     }
 
     for (var i=0; i<stops.length; i++) {


### PR DESCRIPTION
Linear interpolation for heatmap-density and get-property -type interpolate expressions; closes #93