### PR TITLE
Update GL JS for 3D ray-picking mouse interaction support, bump to v0.10.1

### DIFF
--- a/mapboxgl/__init__.py
+++ b/mapboxgl/__init__.py
@@ -1,4 +1,4 @@
 from .viz import CircleViz, GraduatedCircleViz, HeatmapViz, ClusteredCircleViz, ImageViz, RasterTilesViz, ChoroplethViz, LinestringViz
 
-__version__ = "0.10.0"
+__version__ = "0.10.1"
 __all__ = ['CircleViz', 'GraduatedCircleViz', 'HeatmapViz', 'ClusteredCircleViz', 'ImageViz', 'RasterTilesViz', 'ChoroplethViz', 'LinestringViz']

--- a/mapboxgl/templates/base.html
+++ b/mapboxgl/templates/base.html
@@ -4,6 +4,15 @@
 
     mapboxgl.accessToken = '{{ accessToken }}';
 
+    var transformRequest = function(url, resourceType) {
+        const isMapboxRequest = url.slice(8, 22) === 'api.mapbox.com' ||
+          url.slice(10, 26) === 'tiles.mapbox.com';
+      
+        return {
+          url: isMapboxRequest ? url.replace('?', '?pluginName=PythonMapboxgl&') : url
+        }
+    };
+
     var map = new mapboxgl.Map({
         container: 'map',
         attributionControl: false,
@@ -17,22 +26,7 @@
         doubleClickZoom: {{ doubleClickZoomOn|safe }},
         boxZoom: {{ boxZoomOn|safe }},
         preserveDrawingBuffer: {{ preserveDrawingBuffer|safe }},
-        transformRequest: (url, resourceType) => {
-                    if ( url.slice(0,22) == 'https://api.mapbox.com' || 
-                        url.slice(0,26) == 'https://a.tiles.mapbox.com' || 
-                        url.slice(0,26) == 'https://b.tiles.mapbox.com' ||
-                        url.slice(0,26) == 'https://c.tiles.mapbox.com' ||
-                        url.slice(0,26) == 'https://d.tiles.mapbox.com') {
-                        //Add Mapboxgl-Jupyter Plugin identifier for Mapbox API traffic
-                        return {
-                           url: [url.slice(0, url.indexOf("?")+1), "pluginName=PythonMapboxgl&", url.slice(url.indexOf("?")+1)].join('')
-                         }
-                     }
-                     else {
-                         //Do not transform URL for non Mapbox GET requests
-                         return {url: url}
-                     }
-                },
+        transformRequest: transformRequest
     });
 
     {% block attribution %}

--- a/mapboxgl/templates/choropleth.html
+++ b/mapboxgl/templates/choropleth.html
@@ -45,7 +45,10 @@
             "source": "data",
             "type": "fill",
             "paint": {
-                "fill-color": generatePropertyExpression("{{ colorType }}", "{{ colorProperty }}", {{ colorStops }}, "{{ defaultColor }}"),
+                "fill-color": ["case",
+                    ["boolean", ["feature-state", "hover"], false], 
+                    "{{ highlightColor }}",
+                    generatePropertyExpression("{{ colorType }}", "{{ colorProperty }}", {{ colorStops }}, "{{ defaultColor }}")],
                 "fill-opacity": {{ opacity }}
             }
         }, "{{ belowLayer }}" );
@@ -97,7 +100,10 @@
                 source: "data",
                 paint: {
                     "fill-extrusion-opacity": {{ opacity }},
-                    "fill-extrusion-color": generatePropertyExpression("{{ colorType }}", "{{ colorProperty }}", {{ colorStops }}, "{{ defaultColor }}"),
+                    "fill-extrusion-color": ["case",
+                        ["boolean", ["feature-state", "hover"], false], 
+                        "{{ highlightColor }}",
+                        generatePropertyExpression("{{ colorType }}", "{{ colorProperty }}", {{ colorStops }}, "{{ defaultColor }}")],
                     "fill-extrusion-height": generatePropertyExpression("{{ heightType }}", "{{ heightProperty }}", {{ heightStops }}, {{ defaultHeight }}),
                 }
             }, "{{ belowLayer }}");
@@ -128,45 +134,44 @@
         {% block choropleth_popup %}
 
         // Show the popup on mouseover
-        map.on(popupAction, interactionLayer, function(e) {
+        var hoveredStateId = 0;
 
-            {% if popupOpensOnHover %}
+        map.on(popupAction, function(e) {
+            var features = map.queryRenderedFeatures(e.point, {layers: [interactionLayer] });
+
+            if (features.length > 0) {
                 map.getCanvas().style.cursor = 'pointer';
-            {% endif %}
-            
-            let f = e.features[0];
-            let popup_html = '<div>';
+                var f = features[0];
+                newHoveredStateId = f.id;
+                if (newHoveredStateId != hoveredStateId) {
+                    map.removeFeatureState({source: 'data', id: hoveredStateId});
+                    hoveredStateId = newHoveredStateId;
+                }
+                map.setFeatureState({source: 'data', id: hoveredStateId}, { hover: true});
+                let popup_html = '<div>';
 
-            for (key in f.properties) {
-                popup_html += '<li><b> ' + key + '</b>: ' + f.properties[key] + ' </li>'
+                for (key in f.properties) {
+                    popup_html += '<li><b> ' + key + '</b>: ' + f.properties[key] + ' </li>'
+                }
+
+                popup_html += '</div>'
+                popup.setLngLat(e.lngLat)
+                    .setHTML(popup_html)
+                    .addTo(map);
             }
-
-            popup_html += '</div>'
-            popup.setLngLat(e.lngLat)
-                .setHTML(popup_html)
-                .addTo(map);
+            else {
+                map.getCanvas().style.cursor = '';
+                popup.remove();
+                map.removeFeatureState({source: 'data', id: hoveredStateId});
+            }
         });
 
         {% endblock choropleth_popup %}
-
-        // change cursor to pointer when mouse is over the choropleth feature layer
-        map.on('mouseenter', interactionLayer, function () {
-            map.getCanvas().style.cursor = 'pointer';
-        });
-
-        // reset cursor to pointer when mouse leaves the choropleth feature layer
-        map.on('mouseleave', interactionLayer, function() {
-            map.getCanvas().style.cursor = '';
-            {% if popupOpensOnHover %}
-                popup.remove();
-            {% endif %}
-        });
         
-        // Fly to on click
+        // Fly to selected feature on click
         map.on('click', interactionLayer, function(e) {
             map.flyTo({
-                center: e.lngLat,
-                zoom: map.getZoom() + 1
+                center: e.lngLat
             });
         });
 

--- a/mapboxgl/templates/choropleth.html
+++ b/mapboxgl/templates/choropleth.html
@@ -66,7 +66,10 @@
                 {% if lineDashArray %}
                 "line-dasharray": {{ lineDashArray }},
                 {% endif %}
-                "line-color": "{{ lineColor }}",
+                "line-color": ["case",
+                    ["boolean", ["feature-state", "hover"], false], 
+                    "{{ highlightColor }}",
+                    "{{ lineColor }}"],
                 "line-width": {{ lineWidth }},
                 "line-opacity": {{ opacity }}
             }
@@ -87,7 +90,9 @@
             "paint": {
                 "text-halo-color": "{{ labelHaloColor }}",
                 "text-halo-width": generatePropertyExpression('interpolate', 'zoom', [[0,{{ labelHaloWidth }}], [18,5* {{ labelHaloWidth }}]]),
-                "text-color": "{{ labelColor }}"
+                "text-color": ["case",
+                    ["boolean", ["feature-state", "hover"], false], 
+                    "{{ highlightColor }}", "{{ labelColor }}"]
             }
         }, "{{ belowLayer }}" );
 
@@ -137,7 +142,7 @@
         var hoveredStateId = 0;
 
         map.on(popupAction, function(e) {
-            var features = map.queryRenderedFeatures(e.point, {layers: [interactionLayer] });
+            var features = map.queryRenderedFeatures(e.point, {layers: [interactionLayer, 'choropleth-label'] });
 
             if (features.length > 0) {
                 map.getCanvas().style.cursor = 'pointer';
@@ -170,7 +175,7 @@
         
         // Fly to selected feature on click
         map.on('click', interactionLayer, function(e) {
-            map.flyTo({
+            map.easeTo({
                 center: e.lngLat
             });
         });

--- a/mapboxgl/templates/choropleth.html
+++ b/mapboxgl/templates/choropleth.html
@@ -107,6 +107,7 @@
         {% endblock choropleth %}
 
         // Popups
+        var interactionLayer = {% if extrudeChoropleth %} 'choropleth-extrusion' {% else %} 'choropleth-fill' {% endif %};
         {% if popupOpensOnHover %}
             var popupAction = 'mousemove',
                 popupSettings =  {
@@ -127,7 +128,7 @@
         {% block choropleth_popup %}
 
         // Show the popup on mouseover
-        map.on(popupAction, 'choropleth-fill', function(e) {
+        map.on(popupAction, interactionLayer, function(e) {
 
             {% if popupOpensOnHover %}
                 map.getCanvas().style.cursor = 'pointer';
@@ -149,12 +150,12 @@
         {% endblock choropleth_popup %}
 
         // change cursor to pointer when mouse is over the choropleth feature layer
-        map.on('mouseenter', 'choropleth-fill', function () {
+        map.on('mouseenter', interactionLayer, function () {
             map.getCanvas().style.cursor = 'pointer';
         });
 
         // reset cursor to pointer when mouse leaves the choropleth feature layer
-        map.on('mouseleave', 'choropleth-fill', function() {
+        map.on('mouseleave', interactionLayer, function() {
             map.getCanvas().style.cursor = '';
             {% if popupOpensOnHover %}
                 popup.remove();
@@ -162,7 +163,7 @@
         });
         
         // Fly to on click
-        map.on('click', 'choropleth-fill', function(e) {
+        map.on('click', interactionLayer, function(e) {
             map.flyTo({
                 center: e.lngLat,
                 zoom: map.getZoom() + 1

--- a/mapboxgl/templates/circle.html
+++ b/mapboxgl/templates/circle.html
@@ -27,7 +27,8 @@
             "type": "geojson",
             "data": {{ geojson_data }},
             "buffer": 1,
-            "maxzoom": 14
+            "maxzoom": 14,
+            "generateId": true
         });
 
         map.addLayer({
@@ -46,7 +47,10 @@
             "paint": {
                 "text-halo-color": "{{ labelHaloColor }}",
                 "text-halo-width": generatePropertyExpression('interpolate', 'zoom', [[0,{{ labelHaloWidth }}], [18,5* {{ labelHaloWidth }}]]),
-                "text-color": "{{ labelColor }}"
+                "text-color": ["case",
+                    ["boolean", ["feature-state", "hover"], false], 
+                    "{{ highlightColor }}", 
+                    "{{ labelColor }}"]
             }
         }, "{{belowLayer}}" )
         
@@ -58,12 +62,20 @@
             "minzoom": {{ minzoom }},
             "paint": {
                 {% if colorProperty %}
-                    "circle-color": generatePropertyExpression("{{ colorType }}", "{{ colorProperty }}", {{ colorStops }}, "{{ defaultColor }}" ),
+                    "circle-color": ["case",
+                        ["boolean", ["feature-state", "hover"], false], 
+                        "{{ highlightColor }}",
+                        generatePropertyExpression("{{ colorType }}", "{{ colorProperty }}", {{ colorStops }}, "{{ defaultColor }}" )],
                     {% else %}
-                    "circle-color": "{{ defaultColor }}",
+                    "circle-color": ["case",
+                    ["boolean", ["feature-state", "hover"], false], 
+                    "{{ highlightColor }}", "{{ defaultColor }}"],
                 {% endif %}
                 "circle-radius" : generatePropertyExpression('interpolate', 'zoom', [[0,{{ radius }}], [22,10 * {{ radius }}]]),
-                "circle-stroke-color": "{{ strokeColor }}",
+                "circle-stroke-color": ["case",
+                    ["boolean", ["feature-state", "hover"], false], 
+                    "{{ highlightColor }}", 
+                    "{{ strokeColor }}"],
                 "circle-stroke-width": generatePropertyExpression('interpolate', 'zoom', [[0,{{ strokeWidth }}], [18,5* {{ strokeWidth }}]]),
                 "circle-opacity" : {{ opacity }},
                 "circle-stroke-opacity" : {{ opacity }}
@@ -91,48 +103,48 @@
         var popup = new mapboxgl.Popup(popupSettings);
 
         {% block circle_popup %}
+
+        var hoveredStateId = 0;
         
         // Show the popup on mouseover
-        map.on(popupAction, 'circle', function(e) {
+        map.on(popupAction, function(e) {
             
-            {% if popupOpensOnHover %}
+            var features = map.queryRenderedFeatures(e.point, {layers: ['circle', 'label'] });
+
+            if (features.length > 0) {
                 map.getCanvas().style.cursor = 'pointer';
-            {% endif %}
+                var f = features[0];
+                newHoveredStateId = f.id;
+                if (newHoveredStateId != hoveredStateId) {
+                    map.removeFeatureState({source: 'data', id: hoveredStateId});
+                    hoveredStateId = newHoveredStateId;
+                }
+                map.setFeatureState({source: 'data', id: hoveredStateId}, { hover: true});
+                let popup_html = '<div><li><b>Location</b>: ' + f.geometry.coordinates[0].toPrecision(6) + 
+                    ', ' + f.geometry.coordinates[1].toPrecision(6) + '</li>';
 
-            let f = e.features[0];
-            let popup_html = '<div><li><b>Location</b>: ' + f.geometry.coordinates[0].toPrecision(6) + 
-                ', ' + f.geometry.coordinates[1].toPrecision(6) + '</li>';
+                for (key in f.properties) {
+                    popup_html += '<li><b> ' + key + '</b>: ' + f.properties[key] + ' </li>'
+                }
 
-            for (key in f.properties) {
-                popup_html += '<li><b> ' + key + '</b>: ' + f.properties[key] + ' </li>'
+                popup_html += '</div>'
+                popup.setLngLat(e.lngLat)
+                    .setHTML(popup_html)
+                    .addTo(map);
             }
-
-            popup_html += '</div>'
-            popup.setLngLat(e.features[0].geometry.coordinates)
-                .setHTML(popup_html)
-                .addTo(map);
+            else {
+                map.getCanvas().style.cursor = '';
+                popup.remove();
+                map.removeFeatureState({source: 'data', id: hoveredStateId});
+            }
         });
 
         {% endblock circle_popup %}
-
-        // change cursor to pointer when mouse is over the circle feature layer
-        map.on('mouseenter', 'circle', function () {
-            map.getCanvas().style.cursor = 'pointer';
-        });
-
-        // reset cursor to pointer when mouse leaves the circle feature layer
-        map.on('mouseleave', 'circle', function() {
-            map.getCanvas().style.cursor = '';
-            {% if popupOpensOnHover %}
-                popup.remove();
-            {% endif %}
-        });
         
         // Fly to on click
         map.on('click', 'circle', function(e) {
             map.easeTo({
-                center: e.features[0].geometry.coordinates,
-                zoom: map.getZoom() + 1
+                center: e.features[0].geometry.coordinates
             });
         });
     });

--- a/mapboxgl/templates/clustered_circle.html
+++ b/mapboxgl/templates/clustered_circle.html
@@ -23,12 +23,13 @@
 
         map.addSource("data", {
             "type": "geojson",
-            "data": {{ geojson_data }}, //data from dataframe output to geojson
+            "data": {{ geojson_data }},
             "buffer": 0,
             "maxzoom": {{ clusterMaxZoom }} + 1,
             "cluster": true,
             "clusterMaxZoom": {{ clusterMaxZoom }},
-            "clusterRadius": {{ clusterRadius }}
+            "clusterRadius": {{ clusterRadius }},
+            "generateId": true
         });
 
         map.addLayer({
@@ -44,7 +45,10 @@
             "paint": {
                 "text-halo-color": "{{ labelHaloColor }}",
                 "text-halo-width": generatePropertyExpression('interpolate', 'zoom', [[0,{{ labelHaloWidth }}], [18,5* {{ labelHaloWidth }}]]),
-                "text-color": "{{ labelColor }}"
+                "text-color": ["case",
+                    ["boolean", ["feature-state", "hover"], false], 
+                    "{{ highlightColor }}", 
+                    "{{ labelColor }}"]
             }
         }, "{{belowLayer}}" )
 
@@ -56,9 +60,14 @@
             "minzoom": {{ minzoom }},
             "filter": ["has", "point_count"],
             "paint": {
-                "circle-color": generateInterpolateExpression( "point_count", {{ colorStops }} ),
+                "circle-color": ["case",
+                    ["boolean", ["feature-state", "hover"], false], 
+                    "{{ highlightColor }}", 
+                    generateInterpolateExpression( "point_count", {{ colorStops }} )],
                 "circle-radius" : generateInterpolateExpression( "point_count", {{ radiusStops }} ),
-                "circle-stroke-color": "{{ strokeColor }}",
+                "circle-stroke-color": ["case",
+                    ["boolean", ["feature-state", "hover"], false], 
+                    "{{ highlightColor }}", "{{ strokeColor }}"],
                 "circle-stroke-width": generatePropertyExpression('interpolate', 'zoom', [[0,{{ strokeWidth }}], [18,5* {{ strokeWidth }}]]),
                 "circle-opacity" : {{ opacity }},
                 "circle-stroke-opacity" : {{ opacity }}
@@ -73,9 +82,15 @@
             "minzoom": {{ minzoom }},
             "filter": ["!has", "point_count"],
             "paint": {
-                "circle-color": "{{ colorDefault }}",
+                "circle-color": ["case",
+                    ["boolean", ["feature-state", "hover"], false], 
+                    "{{ highlightColor }}", 
+                    "{{ colorDefault }}"],
                 "circle-radius" : generateInterpolateExpression( 'zoom', [[0, {{ radiusDefault }} ], [22,10 * {{ radiusDefault }}]]),
-                "circle-stroke-color": "{{ strokeColor }}",
+                "circle-stroke-color": ["case",
+                    ["boolean", ["feature-state", "hover"], false], 
+                    "{{ highlightColor }}", 
+                    "{{ strokeColor }}"],
                 "circle-stroke-width": generatePropertyExpression('interpolate', 'zoom', [[0,{{ strokeWidth }}], [18,5* {{ strokeWidth }}]]),
                 "circle-opacity" : {{ opacity }},
                 "circle-stroke-opacity" : {{ opacity }}
@@ -104,82 +119,52 @@
         
         {% block clustered_circle_popup %}
 
+        var hoveredStateId = 0;
+        
         // Show the popup on mouseover
-        map.on(popupAction, 'circle-unclustered', function(e) {
+        map.on(popupAction, function(e) {
             
-            {% if popupOpensOnHover %}
+            var features = map.queryRenderedFeatures(e.point, {layers: ['circle-unclustered', 'circle-cluster', 'label'] });
+
+            if (features.length > 0) {
                 map.getCanvas().style.cursor = 'pointer';
-            {% endif %}
+                var f = features[0];
+                newHoveredStateId = f.id;
+                if (newHoveredStateId != hoveredStateId) {
+                    map.removeFeatureState({source: 'data', id: hoveredStateId});
+                    hoveredStateId = newHoveredStateId;
+                }
+                map.setFeatureState({source: 'data', id: hoveredStateId}, { hover: true});
+                let popup_html = '<div><li><b>Location</b>: ' + f.geometry.coordinates[0].toPrecision(6) + 
+                    ', ' + f.geometry.coordinates[1].toPrecision(6) + '</li>';
 
-            let f = e.features[0];
-            let popup_html = '<div><li><b>Location</b>: ' + f.geometry.coordinates[0].toPrecision(6) + 
-                ', ' + f.geometry.coordinates[1].toPrecision(6) + '</li>';
+                for (key in f.properties) {
+                    popup_html += '<li><b> ' + key + '</b>: ' + f.properties[key] + ' </li>'
+                }
 
-            for (key in f.properties) {
-                popup_html += '<li><b> ' + key + '</b>: ' + f.properties[key] + ' </li>'
+                popup_html += '</div>'
+                popup.setLngLat(e.lngLat)
+                    .setHTML(popup_html)
+                    .addTo(map);
             }
-
-            popup_html += '</div>'
-
-            popup.setLngLat(e.features[0].geometry.coordinates)
-                .setHTML(popup_html)
-                .addTo(map);
-        });
-
-        map.on(popupAction, 'circle-cluster', function(e) {
-            map.getCanvas().style.cursor = 'pointer';
-            let f = e.features[0];
-            let popup_html = '<div><li><b>Location</b>: ' + f.geometry.coordinates[0].toPrecision(6) + 
-                ', ' + f.geometry.coordinates[1].toPrecision(6) + '</li>';
-
-            popup_html += '<li><b>Point Count:</b>: ' + f.properties.point_count + ' </li>'
-
-            popup_html += '</div>'
-
-            popup.setLngLat(e.features[0].geometry.coordinates)
-                .setHTML(popup_html)
-                .addTo(map);
+            else {
+                map.getCanvas().style.cursor = '';
+                popup.remove();
+                map.removeFeatureState({source: 'data', id: hoveredStateId});
+            }
         });
 
         {% endblock clustered_circle_popup %}
-
-        // change cursor to pointer when mouse is over the unclustered circle feature layer
-        map.on('mouseenter', 'circle-unclustered', function () {
-            map.getCanvas().style.cursor = 'pointer';
-        });
-
-        // reset cursor to pointer when mouse leaves the unclustered circle feature layer
-        map.on('mouseleave', 'circle-unclustered', function() {
-            map.getCanvas().style.cursor = '';
-            {% if popupOpensOnHover %}
-                popup.remove();
-            {% endif %}
-        });
-
-        // change cursor to pointer when mouse is over the clustered circle feature layer
-        map.on('mouseenter', 'circle-cluster', function () {
-            map.getCanvas().style.cursor = 'pointer';
-        });
-
-        // reset cursor to pointer when mouse leaves the circle-cluster feature layer
-        map.on('mouseleave', 'circle-cluster', function() {
-            map.getCanvas().style.cursor = '';
-            {% if popupOpensOnHover %}
-                popup.remove();
-            {% endif %}
-        });
         
         map.on('click', 'circle-unclustered', function(e) {
             map.easeTo({
-                center: e.features[0].geometry.coordinates,
-                zoom: map.getZoom() + 1
+                center: e.features[0].geometry.coordinates
             });
         });
 
         map.on('click', 'circle-cluster', function(e) {
             map.easeTo({
-                center: e.features[0].geometry.coordinates,
-                zoom: map.getZoom() + 1
+                center: e.features[0].geometry.coordinates
             });
         });
     });

--- a/mapboxgl/templates/graduated_circle.html
+++ b/mapboxgl/templates/graduated_circle.html
@@ -27,7 +27,8 @@
             "type": "geojson",
             "data": {{ geojson_data }}, //data from dataframe output to geojson
             "buffer": 0,
-            "maxzoom": 14
+            "maxzoom": 14,
+            "generateId": true
         });
 
         map.addLayer({
@@ -46,7 +47,10 @@
             "paint": {
                 "text-halo-color": "{{ labelHaloColor }}",
                 "text-halo-width": generatePropertyExpression('interpolate', 'zoom', [[0,{{ labelHaloWidth }}], [18,5* {{ labelHaloWidth }}]]),
-                "text-color": "{{ labelColor }}"
+                "text-color": ["case",
+                    ["boolean", ["feature-state", "hover"], false], 
+                    "{{ highlightColor }}", 
+                    "{{ labelColor }}"]
             }
         }, "{{belowLayer}}" )
 
@@ -58,16 +62,25 @@
             "minzoom": {{ minzoom }},
             "paint": {
                 {% if colorProperty %}
-                    "circle-color": generatePropertyExpression("{{ colorType }}", "{{ colorProperty }}", {{ colorStops }}, "{{ defaultColor }}" ),
+                    "circle-color": ["case",
+                        ["boolean", ["feature-state", "hover"], false], 
+                        "{{ highlightColor }}", 
+                        generatePropertyExpression("{{ colorType }}", "{{ colorProperty }}", {{ colorStops }}, "{{ defaultColor }}" )],
                     {% else %}
-                    "circle-color": "{{ defaultColor }}",
+                    "circle-color": ["case",
+                        ["boolean", ["feature-state", "hover"], false], 
+                        "{{ highlightColor }}", 
+                        "{{ defaultColor }}"],
                 {% endif %}
                 {% if radiusProperty %}
                     "circle-radius" : generatePropertyExpression("{{ radiusType }}", "{{ radiusProperty }}", {{ radiusStops }}, {{ defaultRadius }} ),
                     {% else %}
                     "circle-radius": {{ defaultRadius }},
                 {% endif %}
-                "circle-stroke-color": "{{ strokeColor }}",
+                "circle-stroke-color": ["case",
+                    ["boolean", ["feature-state", "hover"], false], 
+                    "{{ highlightColor }}", 
+                    "{{ strokeColor }}"],
                 "circle-stroke-width": generatePropertyExpression('interpolate', 'zoom', [[0,{{ strokeWidth }}], [18,5* {{ strokeWidth }}]]),
                 "circle-opacity" : {{ opacity }},
                 "circle-stroke-opacity" : {{ opacity }}
@@ -96,48 +109,47 @@
 
         {% block graduated_circle_popup %}
         
+        var hoveredStateId = 0;
+        
         // Show the popup on mouseover
-        map.on(popupAction, 'circle', function(e) {
+        map.on(popupAction, function(e) {
+            
+            var features = map.queryRenderedFeatures(e.point, {layers: ['circle', 'label'] });
 
-            {% if popupOpensOnHover %}
+            if (features.length > 0) {
                 map.getCanvas().style.cursor = 'pointer';
-            {% endif %}
+                var f = features[0];
+                newHoveredStateId = f.id;
+                if (newHoveredStateId != hoveredStateId) {
+                    map.removeFeatureState({source: 'data', id: hoveredStateId});
+                    hoveredStateId = newHoveredStateId;
+                }
+                map.setFeatureState({source: 'data', id: hoveredStateId}, { hover: true});
+                let popup_html = '<div><li><b>Location</b>: ' + f.geometry.coordinates[0].toPrecision(6) + 
+                    ', ' + f.geometry.coordinates[1].toPrecision(6) + '</li>';
 
-            let f = e.features[0];
-            let popup_html = '<div><li><b>Location</b>: ' + f.geometry.coordinates[0].toPrecision(6) + 
-                ', ' + f.geometry.coordinates[1].toPrecision(6) + '</li>';
+                for (key in f.properties) {
+                    popup_html += '<li><b> ' + key + '</b>: ' + f.properties[key] + ' </li>'
+                }
 
-            for (key in f.properties) {
-                popup_html += '<li><b> ' + key + '</b>: ' + f.properties[key] + ' </li>'
+                popup_html += '</div>'
+                popup.setLngLat(e.lngLat)
+                    .setHTML(popup_html)
+                    .addTo(map);
             }
-
-            popup_html += '</div>'
-
-            popup.setLngLat(e.features[0].geometry.coordinates)
-                .setHTML(popup_html)
-                .addTo(map);
+            else {
+                map.getCanvas().style.cursor = '';
+                popup.remove();
+                map.removeFeatureState({source: 'data', id: hoveredStateId});
+            }
         });
 
         {% endblock graduated_circle_popup %}
-
-        // change cursor to pointer when mouse is over the circle feature layer
-        map.on('mouseenter', 'circle', function () {
-            map.getCanvas().style.cursor = 'pointer';
-        });
-        
-        // reset cursor to pointer when mouse leaves the circle feature layer
-        map.on('mouseleave', 'circle', function() {
-            map.getCanvas().style.cursor = '';
-            {% if popupOpensOnHover %}
-                popup.remove();
-            {% endif %}
-        });
         
         // Fly to on click
         map.on('click', 'circle', function(e) {
             map.easeTo({
-                center: e.features[0].geometry.coordinates,
-                zoom: map.getZoom() + 1
+                center: e.features[0].geometry.coordinates
             });
         });
     });

--- a/mapboxgl/templates/linestring.html
+++ b/mapboxgl/templates/linestring.html
@@ -27,7 +27,8 @@
             "type": "geojson",
             "data": {{ geojson_data }},
             "buffer": 1,
-            "maxzoom": 14
+            "maxzoom": 14,
+            "generateId": true
         });
 
         // Add data layer
@@ -44,9 +45,14 @@
                     "line-dasharray": {{ lineDashArray }},
                 {% endif %}
                 {% if colorProperty %}
-                    "line-color": generatePropertyExpression("{{ colorType }}", "{{ colorProperty }}", {{ colorStops }}, "{{ defaultColor }}"),
+                    "line-color": ["case",
+                        ["boolean", ["feature-state", "hover"], false], 
+                        "{{ highlightColor }}",
+                        generatePropertyExpression("{{ colorType }}", "{{ colorProperty }}", {{ colorStops }}, "{{ defaultColor }}")],
                 {% else %}
-                    "line-color": "{{ defaultColor }}",
+                    "line-color": ["case",
+                        ["boolean", ["feature-state", "hover"], false], 
+                        "{{ highlightColor }}","{{ defaultColor }}"],
                 {% endif %}
                 {% if widthProperty %}
                     "line-width": generatePropertyExpression("{{ widthType }}", "{{ widthProperty }}", {{ widthStops }}, {{ defaultWidth }}),
@@ -72,7 +78,10 @@
             "paint": {
                 "text-halo-color": "{{ labelHaloColor }}",
                 "text-halo-width": generatePropertyExpression('interpolate', 'zoom', [[0,{{ labelHaloWidth }}], [18,5* {{ labelHaloWidth }}]]),
-                "text-color": "{{ labelColor }}"
+                "text-color": ["case",
+                    ["boolean", ["feature-state", "hover"], false], 
+                    "{{ highlightColor }}",
+                    "{{ labelColor }}"]
             }
         }, "{{belowLayer}}" );
 
@@ -98,46 +107,44 @@
         
         {% block linestring_popup %}
 
-        // Show the popup on mouseover
-        map.on(popupAction, 'linestring', function(e) {
+        var hoveredStateId = 0;
 
-            {% if popupOpensOnHover %}
+        map.on(popupAction, function(e) {
+            var features = map.queryRenderedFeatures(e.point, {layers: ['linestring', 'linestring-label'] });
+
+            if (features.length > 0) {
                 map.getCanvas().style.cursor = 'pointer';
-            {% endif %}
-            
-            let f = e.features[0];
-            let popup_html = '<div>';
+                var f = features[0];
+                newHoveredStateId = f.id;
+                if (newHoveredStateId != hoveredStateId) {
+                    map.removeFeatureState({source: 'data', id: hoveredStateId});
+                    hoveredStateId = newHoveredStateId;
+                }
+                map.setFeatureState({source: 'data', id: hoveredStateId}, { hover: true});
+                let popup_html = '<div>';
 
-            for (key in f.properties) {
-                popup_html += '<li><b> ' + key + '</b>: ' + f.properties[key] + ' </li>'
+                for (key in f.properties) {
+                    popup_html += '<li><b> ' + key + '</b>: ' + f.properties[key] + ' </li>'
+                }
+
+                popup_html += '</div>'
+                popup.setLngLat(e.lngLat)
+                    .setHTML(popup_html)
+                    .addTo(map);
             }
-
-            popup_html += '</div>'
-            popup.setLngLat(e.lngLat)
-                .setHTML(popup_html)
-                .addTo(map);
+            else {
+                map.getCanvas().style.cursor = '';
+                popup.remove();
+                map.removeFeatureState({source: 'data', id: hoveredStateId});
+            }
         });
 
         {% endblock linestring_popup %}
 
-        // change cursor to pointer when mouse is over the linestring feature layer
-        map.on('mouseenter', 'linestring', function () {
-            map.getCanvas().style.cursor = 'pointer';
-        });
-
-        // reset cursor to pointer when mouse leaves the linestring feature layer
-        map.on('mouseleave', 'linestring', function() {
-            map.getCanvas().style.cursor = '';
-            {% if popupOpensOnHover %}
-                popup.remove();
-            {% endif %}
-        });
-        
         // Fly to on click
         map.on('click', 'linestring', function(e) {
             map.flyTo({
-                center: e.lngLat,
-                zoom: map.getZoom() + 1
+                center: e.lngLat
             });
         });
 

--- a/mapboxgl/templates/main.html
+++ b/mapboxgl/templates/main.html
@@ -240,6 +240,9 @@ function generatePropertyExpression(expressionType, propertyValue, stops, defaul
     if (expressionType == 'match') {
         expression = generateMatchExpression(propertyValue, stops, defaultValue)
     }
+    else if (propertyValue == 'identity') {
+        expression = ['get', propertyValue]
+    }
     else {
         expression = generateInterpolateExpression(propertyValue, stops)
     }

--- a/mapboxgl/templates/map.html
+++ b/mapboxgl/templates/map.html
@@ -11,7 +11,8 @@
             "type": "geojson",
             "data": {{ geojson_data }},
             "buffer": 1,
-            "maxzoom": 14
+            "maxzoom": 14.
+            generateId: true
         });
         
         // Add data layer

--- a/mapboxgl/templates/vector_choropleth.html
+++ b/mapboxgl/templates/vector_choropleth.html
@@ -44,7 +44,10 @@
         "source-layer": "{{ vectorLayer }}",
         "paint": {
             {% if enableDataJoin %}
-            "fill-color": generatePropertyExpression('match', "{{ vectorJoinDataProperty }}", {{ vectorColorStops }}, "{{ defaultColor }}"),
+            "fill-color": ["case",
+                ["boolean", ["feature-state", "hover"], false], 
+                "{{ highlightColor }}", 
+                generatePropertyExpression('match', "{{ vectorJoinDataProperty }}", {{ vectorColorStops }}, "{{ defaultColor }}")],
             {% else %}
                 "fill-color": ["case",
                     ["boolean", ["feature-state", "hover"], false], 
@@ -72,7 +75,10 @@
             {% if lineDashArray %}
                 "line-dasharray": {{ lineDashArray }},
             {% endif %}
-            "line-color": "{{ lineColor }}",
+            "line-color": ["case",
+                ["boolean", ["feature-state", "hover"], false], 
+                "{{ highlightColor }}", 
+                "{{ lineColor }}"],
             "line-width": {{ lineWidth }},
             "line-opacity": {{ opacity }}
         }
@@ -97,7 +103,9 @@
         "paint": {
             "text-halo-color": "{{ labelHaloColor }}",
             "text-halo-width": generatePropertyExpression('interpolate', 'zoom', [[0,{{ labelHaloWidth }}], [18,5* {{ labelHaloWidth }}]]),
-            "text-color": "{{ labelColor }}"
+            "text-color": ["case",
+                ["boolean", ["feature-state", "hover"], false], 
+                "{{ highlightColor }}", "{{ labelColor }}"]
         }
         {% if enableDataJoin %}
         , "filter": layerFilter
@@ -144,7 +152,7 @@
     var hoveredStateId = 0;
 
     map.on(popupAction, function(e) {
-        var features = map.queryRenderedFeatures(e.point, {layers: [interactionLayer] });
+        var features = map.queryRenderedFeatures(e.point, {layers: [interactionLayer, 'choropleth-label'] });
 
         if (features.length > 0) {
             map.getCanvas().style.cursor = 'pointer';

--- a/mapboxgl/templates/vector_choropleth.html
+++ b/mapboxgl/templates/vector_choropleth.html
@@ -146,7 +146,8 @@
 {% block choropleth_popup %}
 
     // Show the popup on mouseover
-    map.on(popupAction, 'choropleth-fill', function(e) {
+    var interactionLayer = {% if extrudeChoropleth %} 'choropleth-extrusion' {% else %} 'choropleth-fill' {% endif %};
+    map.on(popupAction, interactionLayer, function(e) {
 
         {% if popupOpensOnHover %}
             map.getCanvas().style.cursor = 'pointer';

--- a/mapboxgl/templates/vector_choropleth.html
+++ b/mapboxgl/templates/vector_choropleth.html
@@ -44,19 +44,17 @@
         "source-layer": "{{ vectorLayer }}",
         "paint": {
             {% if enableDataJoin %}
-                "fill-color": {
-                    "type": "categorical",
-                    "property": "{{ vectorJoinDataProperty }}", 
-                    "stops": {{ vectorColorStops }}, 
-                    "default": "{{ defaultColor }}"
-                }, 
+            "fill-color": generatePropertyExpression('match', "{{ vectorJoinDataProperty }}", {{ vectorColorStops }}, "{{ defaultColor }}"),
             {% else %}
-                "fill-color": generatePropertyExpression("{{ colorType }}", "{{ colorProperty }}", {{ colorStops }}, "{{ defaultColor }}"),
+                "fill-color": ["case",
+                    ["boolean", ["feature-state", "hover"], false], 
+                    "{{ highlightColor }}",
+                    generatePropertyExpression("{{ colorType }}", "{{ colorProperty }}", {{ colorStops }}, "{{ defaultColor }}")],
             {% endif %}
             "fill-opacity": {{ opacity }}
         }
         {% if enableDataJoin %}
-        , filter: layerFilter
+        , "filter": layerFilter
         {% endif %}
     }, "{{ belowLayer }}");
 
@@ -79,7 +77,7 @@
             "line-opacity": {{ opacity }}
         }
         {% if enableDataJoin %}
-        , filter: layerFilter
+        , "filter": layerFilter
         {% endif %}
     }, "{{ belowLayer }}");
 
@@ -102,7 +100,7 @@
             "text-color": "{{ labelColor }}"
         }
         {% if enableDataJoin %}
-        , filter: layerFilter
+        , "filter": layerFilter
         {% endif %}
     }, "{{ belowLayer }}");
 
@@ -117,25 +115,21 @@
             paint: {
                 "fill-extrusion-opacity": {{ opacity }},
                 {% if enableDataJoin %}
-                    "fill-extrusion-color": {
-                        "type": "categorical",
-                        "property": "{{ vectorJoinDataProperty }}", 
-                        "stops": {{ vectorColorStops }}, 
-                        "default": "{{ defaultColor }}"
-                    },
-                    "fill-extrusion-height": {
-                        "type": "categorical",
-                        "property": "{{ vectorJoinDataProperty }}", 
-                        "stops": {{ vectorHeightStops }}, 
-                        "default": {{ defaultHeight }}
-                    }                
+                "fill-extrusion-color": ["case",
+                        ["boolean", ["feature-state", "hover"], false], 
+                        "{{ highlightColor }}",
+                        generatePropertyExpression('match', "{{ vectorJoinDataProperty }}", {{ vectorColorStops }}, "{{ defaultColor }}")],
+                    "fill-extrusion-height": generatePropertyExpression('match', "{{ vectorJoinDataProperty }}", {{ vectorHeightStops }}, {{ defaultHeight }})                
                 {% else %}
-                    "fill-extrusion-color": generatePropertyExpression("{{ colorType }}", "{{ colorProperty }}", {{ colorStops }}, "{{ defaultColor }}"),
+                    "fill-extrusion-color": ["case",
+                        ["boolean", ["feature-state", "hover"], false], 
+                        "{{ highlightColor }}",
+                        generatePropertyExpression("{{ colorType }}", "{{ colorProperty }}", {{ colorStops }}, "{{ defaultColor }}")],
                     "fill-extrusion-height": generatePropertyExpression("{{ heightType }}", "{{ heightProperty }}", {{ heightStops }}, {{ defaultHeight }}),
                 {% endif %}
             }
             {% if enableDataJoin %}
-            , filter: layerFilter
+            , "filter": layerFilter
             {% endif %}
         }, "{{ belowLayer }}");
 
@@ -147,36 +141,36 @@
 
     // Show the popup on mouseover
     var interactionLayer = {% if extrudeChoropleth %} 'choropleth-extrusion' {% else %} 'choropleth-fill' {% endif %};
-    map.on(popupAction, interactionLayer, function(e) {
+    var hoveredStateId = 0;
 
-        {% if popupOpensOnHover %}
+    map.on(popupAction, function(e) {
+        var features = map.queryRenderedFeatures(e.point, {layers: [interactionLayer] });
+
+        if (features.length > 0) {
             map.getCanvas().style.cursor = 'pointer';
-        {% endif %}
-        
-        let f = e.features[0];
-        let popup_html = '<div>';
+            var f = features[0];
+            newHoveredStateId = f.id;
+            if (newHoveredStateId != hoveredStateId) {
+                map.removeFeatureState({source: 'vector-data', sourceLayer: "{{ vectorLayer }}", id: hoveredStateId});
+                hoveredStateId = newHoveredStateId;
+            }
+            map.setFeatureState({source: 'vector-data', sourceLayer: "{{ vectorLayer }}", id: hoveredStateId}, { hover: true});
+            let popup_html = '<div>';
 
-        for (key in f.properties) {
-            popup_html += '<li><b> ' + key + '</b>: ' + f.properties[key] + ' </li>'
+            for (key in f.properties) {
+                popup_html += '<li><b> ' + key + '</b>: ' + f.properties[key] + ' </li>'
+            }
+
+            popup_html += '</div>'
+            popup.setLngLat(e.lngLat)
+                .setHTML(popup_html)
+                .addTo(map);
         }
-
-        {% if enableDataJoin %}
-
-            // Add property from joined data to vector's feature popup
-            popup_html += '<li><b> ' + "{{ colorProperty }}".toUpperCase() + '</b>: ' + popUpKeys[f.properties["{{ vectorJoinDataProperty }}"]] + ' </li>'
-            
-            {% if extrudeChoropleth %}
-                {% if colorProperty != heightProperty %}
-                    popup_html += '<li><b> ' + "{{ heightProperty }}".toUpperCase() + '</b>: ' + heightPopUpKeys[f.properties["{{ vectorJoinDataProperty }}"]] + ' </li>'
-                {% endif %}
-            {% endif %}
-
-        {% endif %}
-
-        popup_html += '</div>'
-        popup.setLngLat(e.lngLat)
-            .setHTML(popup_html)
-            .addTo(map);
+        else {
+            map.getCanvas().style.cursor = '';
+            popup.remove();
+            map.removeFeatureState({source: 'vector-data', sourceLayer: "{{ vectorLayer }}", id: hoveredStateId});
+        }
     });
 
 {% endblock choropleth_popup %}

--- a/mapboxgl/templates/vector_circle.html
+++ b/mapboxgl/templates/vector_circle.html
@@ -38,21 +38,28 @@
         "minzoom": {{ minzoom }},
         "paint": {
             {% if enableDataJoin %}
-                "circle-color": {
-                    "type": "categorical",
-                    "property": "{{ vectorJoinDataProperty }}", 
-                    "stops": {{ vectorColorStops }}, 
-                    "default": "{{ defaultColor }}"
-                }, 
+                "circle-color": ["case",
+                    ["boolean", ["feature-state", "hover"], false], 
+                    "{{ highlightColor }}", 
+                    generatePropertyExpression('match', "{{ vectorJoinDataProperty }}", {{ vectorColorStops }}, "{{ defaultColor }}")], 
             {% else %}
                 {% if colorProperty %}
-                    "circle-color": generatePropertyExpression("{{ colorType }}", "{{ colorProperty }}", {{ colorStops }}, "{{ defaultColor }}" ),
+                    "circle-color": ["case",
+                        ["boolean", ["feature-state", "hover"], false], 
+                        "{{ highlightColor }}",
+                        generatePropertyExpression("{{ colorType }}", "{{ colorProperty }}", {{ colorStops }}, "{{ defaultColor }}")],
                     {% else %}
-                    "circle-color": "{{ defaultColor }}",
+                    "circle-color": ["case",
+                        ["boolean", ["feature-state", "hover"], false], 
+                        "{{ highlightColor }}",
+                        "{{ defaultColor }}"],
                 {% endif %}
             {% endif %}
             "circle-radius" : generatePropertyExpression('interpolate', 'zoom', [[0,{{ radius }}], [22,10 * {{ radius }}]]),
-            "circle-stroke-color": "{{ strokeColor }}",
+            "circle-stroke-color": ["case",
+                ["boolean", ["feature-state", "hover"], false], 
+                "{{ highlightColor }}",
+                "{{ strokeColor }}"],
             "circle-stroke-width": generatePropertyExpression('interpolate', 'zoom', [[0,{{ strokeWidth }}], [18,5* {{ strokeWidth }}]]),
             "circle-opacity" : {{ opacity }},
             "circle-stroke-opacity" : {{ opacity }}
@@ -80,7 +87,10 @@
         "paint": {
             "text-halo-color": "{{ labelHaloColor }}",
             "text-halo-width": generatePropertyExpression('interpolate', 'zoom', [[0,{{ labelHaloWidth }}], [18,5* {{ labelHaloWidth }}]]),
-            "text-color": "{{ labelColor }}"
+            "text-color": ["case",
+                ["boolean", ["feature-state", "hover"], false], 
+                "{{ highlightColor }}",
+                "{{ labelColor }}"]
         }
         {% if enableDataJoin %}
         , filter: layerFilter
@@ -91,32 +101,36 @@
 
 {% block circle_popup %}
 
-    // Show the popup on mouseover
-    map.on(popupAction, 'circle', function(e) {
+var hoveredStateId = 0;
 
-        {% if popupOpensOnHover %}
+    map.on(popupAction, function(e) {
+        var features = map.queryRenderedFeatures(e.point, {layers: ['circle', 'circle-label'] });
+
+        if (features.length > 0) {
             map.getCanvas().style.cursor = 'pointer';
-        {% endif %}
-               
-        let f = e.features[0];
-        let popup_html = '<div><li><b>Location</b>: ' + f.geometry.coordinates[0].toPrecision(6) + 
-            ', ' + f.geometry.coordinates[1].toPrecision(6) + '</li>';
-
-        {% if enableDataJoin %}
+            var f = features[0];
+            newHoveredStateId = f.id;
+            if (newHoveredStateId != hoveredStateId) {
+                map.removeFeatureState({source: 'vector-data', sourceLayer: "{{ vectorLayer }}", id: hoveredStateId});
+                hoveredStateId = newHoveredStateId;
+            }
+            map.setFeatureState({source: 'vector-data', sourceLayer: "{{ vectorLayer }}", id: hoveredStateId}, { hover: true});
+            let popup_html = '<div>';
 
             for (key in f.properties) {
                 popup_html += '<li><b> ' + key + '</b>: ' + f.properties[key] + ' </li>'
             }
 
-            // Add property from joined data to vector's feature popup
-            popup_html += '<li><b> ' + "{{ colorProperty }}".toUpperCase() + '</b>: ' + popUpKeys[f.properties["{{ vectorJoinDataProperty }}"]] + ' </li>'
-
-        {% endif %}
-
-        popup_html += '</div>'
-        popup.setLngLat(e.features[0].geometry.coordinates)
-            .setHTML(popup_html)
-            .addTo(map);
+            popup_html += '</div>'
+            popup.setLngLat(e.lngLat)
+                .setHTML(popup_html)
+                .addTo(map);
+        }
+        else {
+            map.getCanvas().style.cursor = '';
+            popup.remove();
+            map.removeFeatureState({source: 'vector-data', sourceLayer: "{{ vectorLayer }}", id: hoveredStateId});
+        }
     });
 
 {% endblock circle_popup %}

--- a/mapboxgl/templates/vector_graduated_circle.html
+++ b/mapboxgl/templates/vector_graduated_circle.html
@@ -57,7 +57,10 @@
         "paint": {
             "text-halo-color": "{{ labelHaloColor }}",
             "text-halo-width": generatePropertyExpression('interpolate', 'zoom', [[0,{{ labelHaloWidth }}], [18,5* {{ labelHaloWidth }}]]),
-            "text-color": "{{ labelColor }}"
+            "text-color": ["case",
+                ["boolean", ["feature-state", "hover"], false], 
+                "{{ highlightColor }}", 
+                "{{ labelColor }}"]
         }
         {% if enableDataJoin %}
         , filter: layerFilter
@@ -74,23 +77,22 @@
         "minzoom": {{ minzoom }},
         "paint": {
             {% if enableDataJoin %}
-                "circle-color": {
-                    "type": "categorical",
-                    "property": "{{ vectorJoinDataProperty }}", 
-                    "stops": {{ vectorColorStops }}, 
-                    "default": "{{ defaultColor }}"
-                }, 
-                "circle-radius": {
-                    "type": "categorical",
-                    "property": "{{ vectorJoinDataProperty }}", 
-                    "stops": {{ vectorRadiusStops }}, 
-                    "default": {{ defaultRadius }}
-                }, 
+                "circle-color": ["case",
+                    ["boolean", ["feature-state", "hover"], false], 
+                    "{{ highlightColor }}", 
+                    generatePropertyExpression('match', "{{ vectorJoinDataProperty }}", {{ vectorColorStops }}, "{{ defaultColor }}")],
+                "circle-radius": generatePropertyExpression('match', "{{ vectorJoinDataProperty }}", {{ vectorRadiusStops }}, "{{ defaultRadius }}"),
             {% else %}
                 {% if colorProperty %}
-                    "circle-color": generatePropertyExpression("{{ colorType }}", "{{ colorProperty }}", {{ colorStops }}, "{{ defaultColor }}" ),
+                    "circle-color": ["case",
+                        ["boolean", ["feature-state", "hover"], false], 
+                        "{{ highlightColor }}", 
+                        generatePropertyExpression("{{ colorType }}", "{{ colorProperty }}", {{ colorStops }}, "{{ defaultColor }}" )],
                     {% else %}
-                    "circle-color": "{{ defaultColor }}",
+                    "circle-color": ["case",
+                        ["boolean", ["feature-state", "hover"], false], 
+                        "{{ highlightColor }}", 
+                        "{{ defaultColor }}"],
                 {% endif %}
                 {% if radiusProperty %}
                     "circle-radius" : generatePropertyExpression("{{ radiusType }}", "{{ radiusProperty }}", {{ radiusStops }}, {{ defaultRadius }} ),
@@ -98,7 +100,10 @@
                     "circle-radius": {{ defaultRadius }},
                 {% endif %}
             {% endif %}
-            "circle-stroke-color": "{{ strokeColor }}",
+            "circle-stroke-color": ["case",
+                ["boolean", ["feature-state", "hover"], false], 
+                "{{ highlightColor }}", 
+                "{{ strokeColor }}"],
             "circle-stroke-width": generatePropertyExpression('interpolate', 'zoom', [[0,{{ strokeWidth }}], [18,5* {{ strokeWidth }}]]),
             "circle-opacity" : {{ opacity }},
             "circle-stroke-opacity" : {{ opacity }}
@@ -111,42 +116,38 @@
 {% endblock graduated_circle %}
 
 {% block graduated_circle_popup %}
-        
-    // Show the popup on mouseover
-    map.on(popupAction, 'circle', function(e) {
 
-        {% if popupOpensOnHover %}
+var hoveredStateId = 0;
+
+    map.on(popupAction, function(e) {
+        var features = map.queryRenderedFeatures(e.point, {layers: ['circle', 'circle-label'] });
+
+        if (features.length > 0) {
             map.getCanvas().style.cursor = 'pointer';
-        {% endif %}
+            var f = features[0];
+            newHoveredStateId = f.id;
+            if (newHoveredStateId != hoveredStateId) {
+                map.removeFeatureState({source: 'vector-data', sourceLayer: "{{ vectorLayer }}", id: hoveredStateId});
+                hoveredStateId = newHoveredStateId;
+            }
+            map.setFeatureState({source: 'vector-data', sourceLayer: "{{ vectorLayer }}", id: hoveredStateId}, { hover: true});
+            let popup_html = '<div><li><b>Location</b>: ' + f.geometry.coordinates[0].toPrecision(6) + 
+                ', ' + f.geometry.coordinates[1].toPrecision(6) + '</li>';
 
-        let f = e.features[0];
-        let popup_html = '<div><li><b>Location</b>: ' + f.geometry.coordinates[0].toPrecision(6) + 
-            ', ' + f.geometry.coordinates[1].toPrecision(6) + '</li>';
+            for (key in f.properties) {
+                popup_html += '<li><b> ' + key + '</b>: ' + f.properties[key] + ' </li>'
+            }
 
-        for (key in f.properties) {
-            popup_html += '<li><b> ' + key + '</b>: ' + f.properties[key] + ' </li>'
+            popup_html += '</div>'
+            popup.setLngLat(e.lngLat)
+                .setHTML(popup_html)
+                .addTo(map);
         }
-
-        {% if enableDataJoin %}
-
-            // Add color + radius properties from joined data to vector's feature popup
-            {% if colorProperty %}
-                popup_html += '<li><b> ' + "{{ colorProperty }}".toUpperCase() + '</b>: ' + popUpKeys[f.properties["{{ vectorJoinDataProperty }}"]] + ' </li>'
-            {% endif %}
-
-            {% if radiusProperty %}
-                {% if colorProperty != radiusProperty %}
-                    popup_html += '<li><b> ' + "{{ radiusProperty }}".toUpperCase() + '</b>: ' + popUpKeys[f.properties["{{ vectorJoinDataProperty }}"]] + ' </li>'
-                {% endif %}
-            {% endif %}
-
-        {% endif %}
-
-        popup_html += '</div>'
-
-        popup.setLngLat(e.features[0].geometry.coordinates)
-            .setHTML(popup_html)
-            .addTo(map);
+        else {
+            map.getCanvas().style.cursor = '';
+            popup.remove();
+            map.removeFeatureState({source: 'vector-data', sourceLayer: "{{ vectorLayer }}", id: hoveredStateId});
+        }
     });
 
 {% endblock graduated_circle_popup %}

--- a/mapboxgl/templates/vector_linestring.html
+++ b/mapboxgl/templates/vector_linestring.html
@@ -55,23 +55,22 @@
             {% endif %}
 
             {% if enableDataJoin %}
-                "line-color": {
-                    "type": "categorical",
-                    "property": "{{ vectorJoinDataProperty }}", 
-                    "stops": {{ vectorColorStops }}, 
-                    "default": "{{ defaultColor }}"
-                }, 
-                "line-width": {
-                    "type": "categorical",
-                    "property": "{{ vectorJoinDataProperty }}", 
-                    "stops": {{ vectorWidthStops }}, 
-                    "default": {{ defaultWidth }}
-                },
+                "line-color": ["case",
+                    ["boolean", ["feature-state", "hover"], false], 
+                    "{{ highlightColor }}", 
+                    generatePropertyExpression('match', "{{ vectorJoinDataProperty }}", {{ vectorColorStops }}, "{{ defaultColor }}")],
+                "line-width": generatePropertyExpression('match', "{{ vectorJoinDataProperty }}", {{ vectorWidthStops }}, {{ defaultWidth}} ),
             {% else %}
                 {% if colorProperty %}
-                    "line-color": generatePropertyExpression("{{ colorType }}", "{{ colorProperty }}", {{ colorStops }}, "{{ defaultColor }}"),
+                    "line-color": ["case",
+                        ["boolean", ["feature-state", "hover"], false], 
+                        "{{ highlightColor }}", 
+                        generatePropertyExpression("{{ colorType }}", "{{ colorProperty }}", {{ colorStops }}, "{{ defaultColor }}")],
                 {% else %}
-                    "line-color": "{{ defaultColor }}",
+                    "line-color": ["case",
+                        ["boolean", ["feature-state", "hover"], false], 
+                        "{{ highlightColor }}", 
+                        "{{ defaultColor }}"],
                 {% endif %}
                 {% if widthProperty %}
                     "line-width": generatePropertyExpression("{{ widthType }}", "{{ widthProperty }}", {{ widthStops }}, {{ defaultWidth }}),
@@ -103,7 +102,10 @@
         "paint": {
             "text-halo-color": "{{ labelHaloColor }}",
             "text-halo-width": generatePropertyExpression('interpolate', 'zoom', [[0,{{ labelHaloWidth }}], [18,5* {{ labelHaloWidth }}]]),
-            "text-color": "{{ labelColor }}"
+            "text-color": ["case",
+                ["boolean", ["feature-state", "hover"], false], 
+                "{{ highlightColor }}", 
+                "{{ labelColor }}"]
         }
         {% if enableDataJoin %}
         , filter: layerFilter
@@ -114,39 +116,36 @@
 
 {% block linestring_popup %}
 
-    // Show the popup on mouseover
-    map.on(popupAction, 'linestring', function(e) {
+var hoveredStateId = 0;
 
-        {% if popupOpensOnHover %}
+    map.on(popupAction, function(e) {
+        var features = map.queryRenderedFeatures(e.point, {layers: ['linestring', 'linestring-label'] });
+
+        if (features.length > 0) {
             map.getCanvas().style.cursor = 'pointer';
-        {% endif %}
-        
-        let f = e.features[0];
-        let popup_html = '<div>';
+            var f = features[0];
+            newHoveredStateId = f.id;
+            if (newHoveredStateId != hoveredStateId) {
+                map.removeFeatureState({source: 'vector-data', sourceLayer: "{{ vectorLayer }}", id: hoveredStateId});
+                hoveredStateId = newHoveredStateId;
+            }
+            map.setFeatureState({source: 'vector-data', sourceLayer: "{{ vectorLayer }}", id: hoveredStateId}, { hover: true});
+            let popup_html = '<div>';
 
-        for (key in f.properties) {
-            popup_html += '<li><b> ' + key + '</b>: ' + f.properties[key] + ' </li>'
+            for (key in f.properties) {
+                popup_html += '<li><b> ' + key + '</b>: ' + f.properties[key] + ' </li>'
+            }
+
+            popup_html += '</div>'
+            popup.setLngLat(e.lngLat)
+                .setHTML(popup_html)
+                .addTo(map);
         }
-
-        {% if enableDataJoin %}
-
-            // Add property from joined data to vector's feature popup
-            {% if colorProperty %}
-                popup_html += '<li><b> ' + "{{ colorProperty }}".toUpperCase() + '</b>: ' + popUpKeys[f.properties["{{ vectorJoinDataProperty }}"]] + ' </li>'
-            {% endif %}
-
-            {% if widthProperty %}
-                {% if colorProperty != widthProperty %}
-                    popup_html += '<li><b> ' + "{{ widthProperty }}".toUpperCase() + '</b>: ' + lineWidthPopUpKeys[f.properties["{{ vectorJoinDataProperty }}"]] + ' </li>'
-                {% endif %}
-            {% endif %}
-
-        {% endif %}
-
-        popup_html += '</div>'
-        popup.setLngLat(e.lngLat)
-            .setHTML(popup_html)
-            .addTo(map);
+        else {
+            map.getCanvas().style.cursor = '';
+            popup.remove();
+            map.removeFeatureState({source: 'vector-data', sourceLayer: "{{ vectorLayer }}", id: hoveredStateId});
+        }
     });
 
 {% endblock linestring_popup %}

--- a/mapboxgl/viz.py
+++ b/mapboxgl/viz.py
@@ -588,6 +588,7 @@ class ChoroplethViz(VectorMixin, MapViz):
                  height_default=0.0,
                  height_function_type='interpolate',
                  legend_key_shape='rounded-square',
+                 highlight_color='black',
                  *args,
                  **kwargs):
         """Construct a Mapviz object
@@ -607,8 +608,8 @@ class ChoroplethViz(VectorMixin, MapViz):
         :param height_property: feature property for determining polygon height in 3D extruded choropleth map
         :param height_stops: property for determining 3D extrusion height
         :param height_default: default height for 3D extruded polygons
-        :param height_function_type: roperty to determine `type` used by Mapbox to assign height
-        
+        :param height_function_type: property to determine `type` used by Mapbox to assign height
+        :param highlight_color: color for feature selection, hover, or highlight
         """
         super(ChoroplethViz, self).__init__(data, *args, **kwargs)
         
@@ -627,6 +628,7 @@ class ChoroplethViz(VectorMixin, MapViz):
         self.height_default = height_default
         self.height_function_type = height_function_type
         self.legend_key_shape = legend_key_shape
+        self.highlight_color = highlight_color
 
     def add_unique_template_variables(self, options):
         """Update map template variables specific to heatmap visual"""
@@ -658,6 +660,7 @@ class ChoroplethViz(VectorMixin, MapViz):
             lineStroke=self.line_stroke,
             lineWidth=self.line_width,
             extrudeChoropleth=self.extrude,
+            highlightColor=self.highlight_color
         ))
         if self.extrude:
             options.update(dict(

--- a/mapboxgl/viz.py
+++ b/mapboxgl/viz.py
@@ -345,6 +345,7 @@ class CircleViz(VectorMixin, MapViz):
         :param radius: radius of circle
         :param stroke_color: color of circle stroke outline
         :param stroke_width: with of circle stroke outline
+        :param highlight_color: color for feature selection, hover, or highlight
 
         """
         super(CircleViz, self).__init__(data, *args, **kwargs)
@@ -411,6 +412,7 @@ class GraduatedCircleViz(VectorMixin, MapViz):
         :param radius_function_type: property to determine `type` used by Mapbox to assign radius size
         :param stroke_color: color of circle stroke outline
         :param stroke_width: with of circle stroke outline
+        :param highlight_color: color for feature selection, hover, or highlight
 
         """
         super(GraduatedCircleViz, self).__init__(data, *args, **kwargs)
@@ -548,6 +550,7 @@ class ClusteredCircleViz(MapViz):
         :param stroke_width: with of circle stroke outline
         :param radius_default: radius of circles not contained in a cluster
         :param color_default: color of circles not contained in a cluster
+        :param highlight_color: color for feature selection, hover, or highlight
 
         """
         super(ClusteredCircleViz, self).__init__(data, *args, **kwargs)
@@ -799,7 +802,7 @@ class LinestringViz(VectorMixin, MapViz):
         :param line_width_stops: property to determine line width
         :param line_width_default: property to determine default line width if match lookup fails
         :param line_width_function_type: property to determine `type` used by Mapbox to assign line width
-
+        :param highlight_color: color for feature selection, hover, or highlight
         """
         super(LinestringViz, self).__init__(data, *args, **kwargs)
         

--- a/mapboxgl/viz.py
+++ b/mapboxgl/viz.py
@@ -333,6 +333,7 @@ class CircleViz(VectorMixin, MapViz):
                  stroke_color='grey',
                  stroke_width=0.1,
                  legend_key_shape='circle',
+                 highlight_color='black',
                  *args,
                  **kwargs):
         """Construct a Mapviz object
@@ -359,6 +360,7 @@ class CircleViz(VectorMixin, MapViz):
         self.color_function_type = color_function_type
         self.color_default = color_default
         self.legend_key_shape = legend_key_shape
+        self.highlight_color = highlight_color
 
     def add_unique_template_variables(self, options):
         """Update map template variables specific to circle visual"""
@@ -371,6 +373,7 @@ class CircleViz(VectorMixin, MapViz):
             strokeColor=self.stroke_color,
             radius=self.radius,
             defaultColor=self.color_default,
+            highlightColor=self.highlight_color
         ))
 
         if self.vector_source:
@@ -393,6 +396,7 @@ class GraduatedCircleViz(VectorMixin, MapViz):
                  radius_default=2,
                  radius_function_type='interpolate',
                  legend_key_shape='circle',
+                 highlight_color='black',
                  *args,
                  **kwargs):
         """Construct a Mapviz object
@@ -425,6 +429,7 @@ class GraduatedCircleViz(VectorMixin, MapViz):
         self.stroke_color = stroke_color
         self.stroke_width = stroke_width
         self.legend_key_shape = legend_key_shape
+        self.highlight_color = highlight_color
 
     def add_unique_template_variables(self, options):
         """Update map template variables specific to graduated circle visual"""
@@ -439,6 +444,7 @@ class GraduatedCircleViz(VectorMixin, MapViz):
             radiusStops=self.radius_stops,
             strokeWidth=self.stroke_width,
             strokeColor=self.stroke_color,
+            highlightColor=self.highlight_color
         ))
         if self.vector_source:
             options.update(dict(
@@ -529,6 +535,7 @@ class ClusteredCircleViz(MapViz):
                  stroke_color='grey',
                  stroke_width=0.1,
                  legend_key_shape='circle',
+                 highlight_color='black',
                  *args,
                  **kwargs):
         """Construct a Mapviz object 
@@ -556,6 +563,7 @@ class ClusteredCircleViz(MapViz):
         self.stroke_width = stroke_width
         self.color_default = color_default
         self.legend_key_shape = legend_key_shape
+        self.highlight_color = highlight_color
 
     def add_unique_template_variables(self, options):
         """Update map template variables specific to a clustered circle visual"""
@@ -568,6 +576,7 @@ class ClusteredCircleViz(MapViz):
             strokeWidth=self.stroke_width,
             strokeColor=self.stroke_color,
             radiusDefault=self.radius_default,
+            highlightColor=self.highlight_color
         ))
 
 
@@ -771,6 +780,7 @@ class LinestringViz(VectorMixin, MapViz):
                  line_width_default=1,
                  line_width_function_type='interpolate',
                  legend_key_shape='line',
+                 highlight_color='black',
                  *args,
                  **kwargs):
         """Construct a Mapviz object
@@ -806,6 +816,7 @@ class LinestringViz(VectorMixin, MapViz):
         self.line_width_default = line_width_default
         self.line_width_function_type = line_width_function_type
         self.legend_key_shape = legend_key_shape
+        self.highlight_color = highlight_color
 
     def add_unique_template_variables(self, options):
         """Update map template variables specific to linestring visual"""
@@ -836,6 +847,7 @@ class LinestringViz(VectorMixin, MapViz):
             widthProperty=self.line_width_property,
             widthType=self.line_width_function_type,
             defaultWidth=self.line_width_default,
+            highlightColor=self.highlight_color
         ))
 
         # vector-based linestring map variables

--- a/mapboxgl/viz.py
+++ b/mapboxgl/viz.py
@@ -12,7 +12,7 @@ from mapboxgl.utils import color_map, numeric_map, img_encode, geojson_to_dict_l
 from mapboxgl import templates
 
 
-GL_JS_VERSION = 'v0.51.0'
+GL_JS_VERSION = 'v0.53.0-beta.1'
 
 
 class VectorMixin(object):
@@ -87,7 +87,7 @@ class MapViz(object):
                  opacity=1,
                  div_id='map',
                  height='500px',
-                 style='mapbox://styles/mapbox/light-v9?optimize=true',
+                 style='mapbox://styles/mapbox/light-v10?optimize=true',
                  label_property=None,
                  label_size=8,
                  label_color='#131516',

--- a/mapboxgl/viz.py
+++ b/mapboxgl/viz.py
@@ -12,7 +12,7 @@ from mapboxgl.utils import color_map, numeric_map, img_encode, geojson_to_dict_l
 from mapboxgl import templates
 
 
-GL_JS_VERSION = 'v0.53.0-beta.1'
+GL_JS_VERSION = 'v0.53.0'
 
 
 class VectorMixin(object):

--- a/setup.py
+++ b/setup.py
@@ -33,4 +33,4 @@ setup(
     zip_safe=False,
     install_requires=['jinja2', 'geojson', 'chroma-py', 'colour', 'matplotlib'],
     extras_require={
-        'test': ['pytest', 'pytest-cov', 'codecov', 'mock', 'jupyter', 'Sphinx', 'pandas']})
+        'test': ['pytest>=3.6', 'pytest-cov', 'codecov', 'mock', 'jupyter', 'Sphinx', 'pandas']})


### PR DESCRIPTION
* Updates Mapbox GL JS library to v0.53.0-beta1
* Adds support for ray-picking in 3D choropleth layers
* Updates default Mapbox style to be `light-v10` which uses the new data layers available in Streets-v8
* Adds a `hover_color` parameter for showing feature interactions with the mouse/touch actions
* Adds support for `identity` function function.  Useful for creating 3D choropleth with heights from values stored in vector tile properties.  - https://github.com/mapbox/mapboxgl-jupyter/issues/144

To Do
- [x] Add feature highlight actions for all layer types
- [ ] Add docs for `highlight_color`
- [ ] Get a PR review
- [ ] Upgrade GL JS to v 0.53 (non-beta) on release
- [ ] Add support for identity function https://github.com/mapbox/mapboxgl-jupyter/issues/144
- [ ] Add support for scale https://github.com/mapbox/mapboxgl-jupyter/issues/143