### PR TITLE
Support custom choropleth border opacity

### DIFF
--- a/docs/viz.md
+++ b/docs/viz.md
@@ -360,7 +360,7 @@ viz.show()
 The `ChoroplethViz` object handles the creation of a choropleth map and inherits from the `MapViz` class. It applies a thematic map style to polygon features with color shading in proportion to the intensity of the data being displayed. Choropleth polygons can be initialized with geojson source or vector source styled using the data-join technique.
 
 ### Params
-**ChoroplethViz**(_data, color_property=None, color_stops=None, color_default='grey', color_function_type='interpolate', line_color='white', line_stroke='solid', line_width=1, height_property=None, height_stops=None, height_default=0.0, height_function_type='interpolate', \*args, \*\*kwargs_)
+**ChoroplethViz**(_data, color_property=None, color_stops=None, color_default='grey', color_function_type='interpolate', line_color='white', line_stroke='solid', line_width=1, line_opacity=1, height_property=None, height_stops=None, height_default=0.0, height_function_type='interpolate', \*args, \*\*kwargs_)
 
 Parameter | Description | Example
 --|--|--
@@ -373,6 +373,7 @@ color_function_type | property to determine type of expression used by Mapbox to
 line_color | property to determine choropleth border line color | '#FFFFFF'
 line_stroke | property to determine choropleth border line stroke (one of solid (-), dashed (--), dotted (:), dash dot (-.)) | 'solid' or '-'
 line_width | property to determine choropleth border line width | 1
+line_opacity | opacity of choropleth line layer | 1
 height_property | feature property for determining polygon height in 3D extruded choropleth map | 'density'
 height_stops | property for determining 3D extrusion height | [[0, 0], [500, 50000], [1500, 150000]]
 height_default | default height (in meters) for 3D extruded polygons on map | 1500.0
@@ -397,6 +398,7 @@ viz = ChoroplethViz('us-states.geojson',
                      line_stroke='--',
                      line_color='rgb(128,0,38)',
                      line_width=1,
+                     line_opacity=0.9,
                      opacity=0.8,
                      center=(-96, 37.8),
                      zoom=3,

--- a/examples/notebooks/choropleth-viz-example.ipynb
+++ b/examples/notebooks/choropleth-viz-example.ipynb
@@ -47,6 +47,7 @@
     "                    line_stroke='--',\n",
     "                    line_color='rgb(128,0,38)',\n",
     "                    line_width=1,\n",
+    "                    line_opacity=0.9,\n",
     "                    opacity=0.8,\n",
     "                    center=(-96, 37.8),\n",
     "                    zoom=3,\n",

--- a/mapboxgl/templates/choropleth.html
+++ b/mapboxgl/templates/choropleth.html
@@ -71,7 +71,7 @@
                     "{{ highlightColor }}",
                     "{{ lineColor }}"],
                 "line-width": {{ lineWidth }},
-                "line-opacity": {{ opacity }}
+                "line-opacity": {{ lineOpacity }}
             }
         }, "{{ belowLayer }}" );
 

--- a/mapboxgl/templates/vector_choropleth.html
+++ b/mapboxgl/templates/vector_choropleth.html
@@ -80,7 +80,7 @@
                 "{{ highlightColor }}", 
                 "{{ lineColor }}"],
             "line-width": {{ lineWidth }},
-            "line-opacity": {{ opacity }}
+            "line-opacity": {{ lineOpacity }}
         }
         {% if enableDataJoin %}
         , "filter": layerFilter

--- a/mapboxgl/viz.py
+++ b/mapboxgl/viz.py
@@ -632,6 +632,7 @@ class ChoroplethViz(VectorMixin, MapViz):
                  line_color='white',
                  line_stroke='solid',
                  line_width=1,
+                 line_opacity=1,
                  height_property=None,      
                  height_stops=None,
                  height_default=0.0,
@@ -654,6 +655,7 @@ class ChoroplethViz(VectorMixin, MapViz):
         :param line_color: property to determine choropleth line color
         :param line_stroke: property to determine choropleth line stroke (solid, dashed, dotted, dash dot)
         :param line_width: property to determine choropleth line width
+        :param line_opacity: opacity of choropleth line layer
         :param height_property: feature property for determining polygon height in 3D extruded choropleth map
         :param height_stops: property for determining 3D extrusion height
         :param height_default: default height for 3D extruded polygons
@@ -672,6 +674,7 @@ class ChoroplethViz(VectorMixin, MapViz):
         self.line_color = line_color
         self.line_stroke = line_stroke
         self.line_width = line_width
+        self.line_opacity = line_opacity
         self.height_property = height_property
         self.height_stops = height_stops
         self.height_default = height_default
@@ -708,6 +711,7 @@ class ChoroplethViz(VectorMixin, MapViz):
             lineDashArray=self.line_dash_array,
             lineStroke=self.line_stroke,
             lineWidth=self.line_width,
+            lineOpacity=self.line_opacity,
             extrudeChoropleth=self.extrude,
             highlightColor=self.highlight_color
         ))


### PR DESCRIPTION
Separate choropleth border opacity (`line_opacity`) from main layer `opacity`.  Allows user to create ChoroplethViz without any fill to the polygons.

Example:
```
viz = ChoroplethViz('https://raw.githubusercontent.com/mapbox/mapboxgl-jupyter/master/examples/data/us-states.geojson', 
                    access_token=token,
                    color_stops=[],
                    line_stroke='-',
                    line_color='white',
                    line_width=1,
                    opacity=0,
                    line_opacity=1,
                    center=(-96, 37.8),
                    style='mapbox://styles/mapbox/dark-v9?optimize=true')
viz.show()
```

Closes #156 