### PR TITLE
Add missing dependencies requests and ipython

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -31,6 +31,6 @@ setup(
         'mapboxgl': ['templates/*']},
     include_package_data=True,
     zip_safe=False,
-    install_requires=['jinja2', 'geojson', 'chroma-py', 'colour', 'matplotlib'],
+    install_requires=['jinja2', 'geojson', 'chroma-py', 'colour', 'matplotlib', 'ipython', 'requests'],
     extras_require={
         'test': ['pytest>=3.6', 'pytest-cov', 'codecov', 'mock', 'jupyter', 'Sphinx', 'pandas']})


### PR DESCRIPTION
The file viz.py imports both requests and IPython, but these are not
declared in setup.py.  Because of this, after a `pip install mapboxgl`,
attempting to `import mapgoxgl.utils` fails.

This adds the packages to setup.py, and after this the import succeeds.