### PR TITLE
Fixing syntax error in map.html template

### DIFF
--- a/mapboxgl/templates/map.html
+++ b/mapboxgl/templates/map.html
@@ -11,7 +11,7 @@
             "type": "geojson",
             "data": {{ geojson_data }},
             "buffer": 1,
-            "maxzoom": 14.
+            "maxzoom": 14,
             generateId: true
         });
         


### PR DESCRIPTION
In map.html, a terminating comma was replaced with a period.  This made
the javascript object invalid, resulting in a page that wouldn't render.
This fixes that.