### PR TITLE
Add plumbing for width and height in `MapViz.create_html`

### DIFF
--- a/mapboxgl/templates/main.html
+++ b/mapboxgl/templates/main.html
@@ -13,7 +13,7 @@
 
 <style type='text/css'>
     body { margin:0; padding:0; }
-    .map { position: absolute; top:0; bottom:0; width:100%; }
+    .map { position: absolute; top:0; bottom:0; width: {{ mapwidth }}; height:{{ mapheight }} }
     .legend {
         background-color: {{ legendFill }};
         color: {{ legendTextColor }};

--- a/mapboxgl/viz.py
+++ b/mapboxgl/viz.py
@@ -298,6 +298,8 @@ class MapViz(object):
             scalePosition=self.scale_position,
             scaleFillColor=self.scale_background_color,
             scaleTextColor=self.scale_text_color,
+            mapwidth=self.width,
+            mapheight=self.height
         )
 
         if self.legend:


### PR DESCRIPTION
This PR allows the `width` and `height` attributes of a `MapViz` instance to be sent to the `.map` css class in `templates/main.html`, this allowing `create_html` to render non-fullscreen maps. 

Use-case: I am building html reports that utilize MapViz objects in conjunction with other plotting libraries (plotly, matplotlib, etc.), and I need the flexibility to change the size of the map for the html report. 