### PR TITLE
Add manifest including non-Python files too

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,0 +1,1 @@
+recursive-include mapboxgl/templates/ *


### PR DESCRIPTION
Ref: https://docs.python.org/3/distutils/sourcedist.html#manifest

>Sometimes this is enough, but usually you will want to specify additional files to distribute. The typical way to do this is to write a manifest template, called MANIFEST.in by default. The manifest template is just a list of instructions for how to generate your manifest file, MANIFEST, which is the exact list of files to include in your source distribution. The sdist command processes this template and generates a manifest based on its instructions and what it finds in the filesystem.

After this change, when I test with:

```bash
(venv) $ python setup.py sdist
```

The generated dist archive contains the template files. Without the manifest the `sdist` produced doesn't include the `templates` folder, probably because it doesn't have any Python files.

I think this PR should fix:

- https://github.com/mapbox/mapboxgl-jupyter/issues/163
- https://github.com/conda-forge/mapboxgl-feedstock/issues/2

Thank you!
-Bruno